### PR TITLE
Blog index

### DIFF
--- a/blog/static/blog/style.css
+++ b/blog/static/blog/style.css
@@ -50,3 +50,27 @@ body {
   font-size: 1.2em;
 }
 
+.blog-container {
+  margin-top: 15%;
+}
+
+.blog-card {
+  border-color: #90BEEA;
+  border-radius: 1px;
+  box-shadow: 8px 8px 0px 0px #90BEEA;
+  margin-bottom: 30px;
+  padding: 5px 15px 5px 15px;
+}
+
+.blog-link:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-link {
+  color: inherit;
+}
+
+.blog-title {
+  font-size: 2.0em;
+}

--- a/blog/templates/blog/index.html
+++ b/blog/templates/blog/index.html
@@ -1,20 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}Blog{% endblock %}
+{% block title %}Blog - TAP{% endblock %}
 
 {% block content %}
-<div class="container">
-  <div class="row">
+<div class="blog-container container">
     {% for blog_post in blog_posts %}
-      <div class="px-1 py-1 col-lg-4">
-        <a href="{% url 'blog:detail' blog_post.id %}">
-          <div class="card preview text-center">
-            <div class="blog-post-date">{{ blog_post.created_at }}</div>
-            <div class="blog-post-title text-truncate">{{ blog_post.title }}</div>
-          </div>
-        </a>
+      <div class="row">
+        <div class="blog-card card col-md">
+          <div class="timestamp">{{ blog_post.created_at }}</div>
+          <div class="blog-title text-truncate">{{ blog_post.title }}</div>
+          <a href="{% url 'blog:detail' blog_post.id %}" class="stretched-link"></a>
+        </div>
       </div>
     {% endfor %}
-  </div>
 </div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
     {% load static %}
     <link rel="stylesheet" type="text/css" href="{% static 'blog/style.css' %}">
     <title>{% block title %}TAP{% endblock %}</title>
@@ -30,8 +30,8 @@
     {% block content %}{% endblock %}
     <footer class="footer py-3">
     </footer>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js" integrity="sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
Updated Bootstrap to 4.6.0 so I could use stretched-links to make my blog index page cards clickable. Previously was using a jerry-rigged card wrapped with an 'a' element to make the elements clickable. Unfortunately, it was messing with the spacing of containers/cards, so I wanted to remove it and move toward a more Bootstrapified implementation rather than going further down the rabbit hole of make-shift CSS/HTML.